### PR TITLE
add elco sentences

### DIFF
--- a/datasets/hallucinate.py
+++ b/datasets/hallucinate.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import openai
+
+## Generate short phrase/sentence using ChatGPT given the emoji from ELCo and the corresponding label ##
+
+# Load the ELCo dataset
+elco = pd.read_csv("ELCo.csv")
+print(elco.head())
+
+# Set your OpenAI API key
+openai.api_key = 'your-api-key-here'
+
+# Function to generate a short phrase or sentence from emoji and label
+def generate_phrase_from_emoji_and_label(emoji, label):
+    # Use the OpenAI API to generate a sentence
+    prompt = f"Generate a short phrase or sentence using the emoji: {emoji} and the label concept: {label}. The sentence should be relevant to the emoji and label."
+
+    # Call the OpenAI API
+    response = openai.Completion.create(
+        engine="text-davinci-003",  # or "gpt-4" if you prefer
+        prompt=prompt,
+        max_tokens=50,  # Limit the length of the generated text
+        n=1,  # Generate one sentence
+        stop=None,
+        temperature=0.7  # Adjust for more creativity in sentence generation
+    )
+
+    # Extract and return the generated sentence
+    sentence = response.choices[0].text.strip()
+    return sentence
+
+def hallucinate(dataset):
+    # Create a new column for the generated sentences
+    dataset['generated_sentence'] = dataset.apply(
+        lambda row: generate_phrase_from_emoji_and_label(row['EM'], row['EN']),
+        axis=1
+    )
+
+    # Save the updated DataFrame to a new CSV file
+    dataset.to_csv("ELCo_with_sentences.csv", index=False)
+
+    # Print the first few rows of the updated DataFrame
+    print(dataset.head())
+
+def test_hallucinate():
+    elco_test = elco.head()
+    hallucinate(elco_test)
+    

--- a/requirements_cpu.txt
+++ b/requirements_cpu.txt
@@ -1,3 +1,4 @@
+# Package dependencies
 datasets>=3.3.2
 ipykernel>=6.29.5
 jupyter>=1.1.1
@@ -7,7 +8,7 @@ transformers>=4.49.0
 trl>=0.15.2
 
 # PyTorch for CPU
---index-url https://download.pytorch.org/whl/cpu
+# --index-url https://download.pytorch.org/whl/cpu
 torch>=2.6.0
 torchvision>=0.21.0
 


### PR DESCRIPTION
hallucinate.py uses chatgpt to convert the current emoji and concept label to a coherent phrase or sentence, that can be used to train our encoder